### PR TITLE
Fixed 自动版本的资源错误提示没有可识别名称

### DIFF
--- a/src/TridentCore.Core/Clients/IModrinthClient.cs
+++ b/src/TridentCore.Core/Clients/IModrinthClient.cs
@@ -41,8 +41,10 @@ public interface IModrinthClient
     [Get("/v3/project/{projectId}/version")]
     Task<IReadOnlyList<VersionInfo>> GetProjectVersionsAsync(
         string projectId,
-        string? versionType = null,
-        string? loaders = null
+        [AliasAs("version_type")] string? versionType = null,
+        string? loaders = null,
+        [AliasAs("game_versions")] string? gameVersions = null,
+        [AliasAs("include_changelog")] bool includeChangelog = false
     );
 
     [Get("/v3/version_file/{hash}")]

--- a/src/TridentCore.Core/Repositories/CurseForgeRepository.cs
+++ b/src/TridentCore.Core/Repositories/CurseForgeRepository.cs
@@ -180,7 +180,8 @@ public class CurseForgeRepository(string label, ICurseForgeClient client) : IRep
                         return CurseForgeHelper.ToPackage(label, mod, file);
                     }
 
-                    throw new ResourceNotFoundException($"{pid}/{vid ?? "*"} has no matched version");
+                    throw new ResourceNotFoundException(
+                        $"{mod.Name} ({label}:{pid}/{vid ?? "*"}) has no matched version for {FormatTarget(filter)}");
                 }
             }
             catch (ApiException ex)
@@ -225,7 +226,8 @@ public class CurseForgeRepository(string label, ICurseForgeClient client) : IRep
                                         return file != null
                                                    ? (id: x, mod, file)
                                                    : throw new
-                                                         ResourceNotFoundException($"{modId}/* has no matched version");
+                                                         ResourceNotFoundException(
+                                                             $"{mod.Name} ({label}:{modId}/*) has no matched version for {FormatTarget(filter)}");
                                     }
 
                                     throw new FormatException($"{x.Identity} is not well formatted into modId");
@@ -350,4 +352,6 @@ public class CurseForgeRepository(string label, ICurseForgeClient client) : IRep
     }
 
     #endregion
+
+    private static string FormatTarget(Filter filter) => $"{filter.Version ?? "*"}/{filter.Loader ?? "*"}";
 }

--- a/src/TridentCore.Core/Repositories/ModrinthRepository.cs
+++ b/src/TridentCore.Core/Repositories/ModrinthRepository.cs
@@ -137,11 +137,12 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
                         .GetProjectVersionsAsync(
                             pid,
                             null,
-                            filter.Loader is not null
+                            project.ProjectTypes.FirstOrDefault() == ModrinthHelper.RESOURCENAME_MOD && filter.Loader is not null
                                 ? ArrayParameterConstructor([
                                     ModrinthHelper.LoaderIdToName(filter.Loader),
                                 ])
-                                : null
+                                : null,
+                            filter.Version is not null ? ArrayParameterConstructor([filter.Version]) : null
                         )
                         .ConfigureAwait(false),
                     client.GetTeamMembersAsync(project.TeamId).ConfigureAwait(false)
@@ -200,11 +201,12 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
                     .GetProjectVersionsAsync(
                         x.Identity,
                         null,
-                        filter.Loader is not null
+                        projects.GetValueOrDefault(x.Identity)?.ProjectTypes?.FirstOrDefault() == ModrinthHelper.RESOURCENAME_MOD && filter.Loader is not null
                             ? ArrayParameterConstructor([
                                 ModrinthHelper.LoaderIdToName(filter.Loader),
                             ])
-                            : null
+                            : null,
+                        filter.Version is not null ? ArrayParameterConstructor([filter.Version]) : null
                     )
                     .ConfigureAwait(false);
                 var chosen = versions
@@ -286,7 +288,12 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
                 ? ModrinthHelper.LoaderIdToName(filter.Loader)
                 : null;
         var first = await client
-            .GetProjectVersionsAsync(pid, null, loader is not null ? $"[\"{loader}\"]" : null)
+            .GetProjectVersionsAsync(
+                pid,
+                null,
+                loader is not null ? $"[\"{loader}\"]" : null,
+                filter.Version is not null ? ArrayParameterConstructor([filter.Version]) : null
+            )
             .ConfigureAwait(false);
         var all = first
             .Where(x => filter.Version is null || x.GameVersions.Contains(filter.Version))

--- a/src/TridentCore.Core/Repositories/ModrinthRepository.cs
+++ b/src/TridentCore.Core/Repositories/ModrinthRepository.cs
@@ -155,7 +155,7 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
                 if (found == null)
                 {
                     throw new ResourceNotFoundException(
-                        $"{pid}/{vid ?? "*"} has no matched version"
+                        $"{project.Name} ({label}:{pid}/{vid ?? "*"}) has no matched version for {FormatTarget(filter)}"
                     );
                 }
 
@@ -184,6 +184,14 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
         var knownVids = batchArray.Where(x => x.Version is not null).ToArray();
         var unknownVids = batchArray.Where(x => x.Version is null).ToArray();
 
+        var projects = (
+            await client
+                .GetMultipleProjectsAsync(
+                    ArrayParameterConstructor(batchArray.Select(bm => bm.Identity))
+                )
+                .ConfigureAwait(false)
+        ).ToDictionary(x => x.Id);
+
         // 这一块依旧没法一次性拿全，都怪 Modrinth 的 API 设计
         var unknownProjectVersionsTasks = unknownVids
             .Select(async x =>
@@ -206,8 +214,9 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
                     );
                 if (chosen == null)
                 {
+                    var name = projects.GetValueOrDefault(x.Identity)?.Name ?? x.Identity;
                     throw new ResourceNotFoundException(
-                        $"{x.Identity}/{x.Version ?? "*"} has no matched version"
+                        $"{name} ({label}:{x.Identity}/{x.Version ?? "*"}) has no matched version for {FormatTarget(filter)}"
                     );
                 }
 
@@ -221,13 +230,6 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
             .GetMultipleVersionsAsync(ArrayParameterConstructor(knownVids.Select(bm => bm.Version)))
             .ConfigureAwait(false);
 
-        var projects = (
-            await client
-                .GetMultipleProjectsAsync(
-                    ArrayParameterConstructor(batchArray.Select(bm => bm.Identity))
-                )
-                .ConfigureAwait(false)
-        ).ToDictionary(x => x.Id);
         var membersTasks = projects
             .Keys.Select(async x =>
                 (Id: x, Members: await client.GetTeamMembersAsync(x).ConfigureAwait(false))
@@ -298,4 +300,6 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
 
     private static string ArrayParameterConstructor(IEnumerable<string?> members) =>
         "[\"" + string.Join("\",\"", members.Where(x => x is not null)) + "\"]";
+
+    private static string FormatTarget(Filter filter) => $"{filter.Version ?? "*"}/{filter.Loader ?? "*"}";
 }

--- a/src/TridentCore.Core/Repositories/ModrinthRepository.cs
+++ b/src/TridentCore.Core/Repositories/ModrinthRepository.cs
@@ -132,16 +132,16 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
             }
             else
             {
+                var loader = ModrinthHelper.GetVersionLoaderFilter(
+                    project.ProjectTypes.FirstOrDefault(),
+                    filter.Loader
+                );
                 var (versionsTask, membersTask) = (
                     client
                         .GetProjectVersionsAsync(
                             pid,
                             null,
-                            project.ProjectTypes.FirstOrDefault() == ModrinthHelper.RESOURCENAME_MOD && filter.Loader is not null
-                                ? ArrayParameterConstructor([
-                                    ModrinthHelper.LoaderIdToName(filter.Loader),
-                                ])
-                                : null,
+                            loader is not null ? ArrayParameterConstructor([loader]) : null,
                             filter.Version is not null ? ArrayParameterConstructor([filter.Version]) : null
                         )
                         .ConfigureAwait(false),
@@ -197,15 +197,15 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
         var unknownProjectVersionsTasks = unknownVids
             .Select(async x =>
             {
+                var loader = ModrinthHelper.GetVersionLoaderFilter(
+                    projects.GetValueOrDefault(x.Identity)?.ProjectTypes?.FirstOrDefault(),
+                    filter.Loader
+                );
                 var versions = await client
                     .GetProjectVersionsAsync(
                         x.Identity,
                         null,
-                        projects.GetValueOrDefault(x.Identity)?.ProjectTypes?.FirstOrDefault() == ModrinthHelper.RESOURCENAME_MOD && filter.Loader is not null
-                            ? ArrayParameterConstructor([
-                                ModrinthHelper.LoaderIdToName(filter.Loader),
-                            ])
-                            : null,
+                        loader is not null ? ArrayParameterConstructor([loader]) : null,
                         filter.Version is not null ? ArrayParameterConstructor([filter.Version]) : null
                     )
                     .ConfigureAwait(false);
@@ -282,16 +282,15 @@ public class ModrinthRepository(string label, IModrinthClient client) : IReposit
     )
     {
         var project = await client.GetProjectAsync(pid).ConfigureAwait(false);
-        var type = project.ProjectTypes.FirstOrDefault();
-        var loader =
-            type == ModrinthHelper.RESOURCENAME_MOD
-                ? ModrinthHelper.LoaderIdToName(filter.Loader)
-                : null;
+        var loader = ModrinthHelper.GetVersionLoaderFilter(
+            project.ProjectTypes.FirstOrDefault(),
+            filter.Loader
+        );
         var first = await client
             .GetProjectVersionsAsync(
                 pid,
                 null,
-                loader is not null ? $"[\"{loader}\"]" : null,
+                loader is not null ? ArrayParameterConstructor([loader]) : null,
                 filter.Version is not null ? ArrayParameterConstructor([filter.Version]) : null
             )
             .ConfigureAwait(false);

--- a/src/TridentCore.Core/Utilities/ModrinthHelper.cs
+++ b/src/TridentCore.Core/Utilities/ModrinthHelper.cs
@@ -43,6 +43,9 @@ public static class ModrinthHelper
             _ => null,
         };
 
+    public static string? GetVersionLoaderFilter(string? projectType, string? loaderId) =>
+        projectType == RESOURCENAME_MOD ? LoaderIdToName(loaderId) : null;
+
     public static string ResourceKindToUrlKind(ResourceKind kind) =>
         kind switch
         {


### PR DESCRIPTION
当某个资源找不到可用版本时会提示：
`PID/* no matched version`
其中没有可以有效识别的名称。

修复了以下问题：
- [x] 提示信息扩展，包含资源名称和 PID
- [x] 修复了无条件传参 loader 导致 Modrinth 资源包**总是无可用版本**的问题
